### PR TITLE
Added: Dummy (non-netcode) UDP-server

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -27,18 +27,24 @@ func run_server(port int) {
 	tcpObj := serverProtos.NewTcpObj("TcpConn1")
 	tcpObj.Start(ch)
 
+	udpObj := serverProtos.NewUdpObj("UdpConn1")
+	udpObj.Start(ch)
+
 	start := time.Now()
 	for {
-		fmt.Println("try to receive send something from channel")
+		fmt.Println("MAIN: try to receive something from channel")
+		// This delivers the client REQUEST
+		// Note: We simulate "client sending behavior" within handleTcpConn
+		// The netcode has to remove that and wait for incoming conns
 		result := <- ch
-		fmt.Println("Result: ", result)
+		fmt.Println("\nResult: ", result)
 
-		result.ConnObj.WriteAnswer([]byte("tcpStuffSent"))
+		result.ConnObj.WriteAnswer([]byte("Reply"))
 				
 		time.Sleep(2 * time.Millisecond)
 
 		elapsed := time.Since(start)
-		fmt.Println("Elapsed time recv channel: ", elapsed)
+		fmt.Println("MAIN: Elapsed time recv channel: ", elapsed)
 		start = time.Now()
 	}
 }

--- a/ctrl/serverProtos/tcp.go
+++ b/ctrl/serverProtos/tcp.go
@@ -46,7 +46,7 @@ func (tcp *TcpObj) handleTcpConn(ch chan<- shared.ChResult) {
 
 	start := time.Now()
 	for {
-		fmt.Println("send something into channel")
+		fmt.Println("\nTCP: Sending into channel")
 		chReply := new(shared.ChResult)
 		chReply.DummyJson = "tcpStuffReceived"
 		chReply.ConnObj = tcpConn
@@ -55,7 +55,7 @@ func (tcp *TcpObj) handleTcpConn(ch chan<- shared.ChResult) {
 
 		time.Sleep(1 * time.Millisecond)
 		elapsed := time.Since(start)
-		fmt.Println("Elapsed time sending channel: ", elapsed)
+		fmt.Println("TCP: Elapsed time sending channel: ", elapsed)
 		start = time.Now()
 	}
 }

--- a/ctrl/serverProtos/udp.go
+++ b/ctrl/serverProtos/udp.go
@@ -1,1 +1,60 @@
 package serverProtos
+
+import "fmt"
+import "time"
+import "github.com/monfron/mapago/ctrl/shared"
+
+// classes
+
+type UdpObj struct {
+	connName string
+}
+
+type UdpConnObj struct {
+}
+
+// Constructors
+
+func NewUdpObj(name string) *UdpObj {
+	udpObj := new(UdpObj)
+	udpObj.connName = name
+	return udpObj
+}
+
+func NewUdpConnObj() *UdpConnObj {
+	udpConnObj := new(UdpConnObj)
+	return udpConnObj
+}
+
+// TODO Interfaces
+func (udpConn *UdpConnObj) WriteAnswer(answer []byte) {
+	fmt.Println(answer)
+}
+
+// module start
+func (udp *UdpObj) Start(ch chan<- shared.ChResult) {
+	fmt.Println("UdpObj start() called")
+	go udp.handleUdpConn(ch)
+}
+
+func (udp *UdpObj) handleUdpConn(ch chan<- shared.ChResult) {
+	fmt.Println("handleUdpConn goroutine called")
+
+	udpConn := NewUdpConnObj()
+	fmt.Println("udp conn: ", *udpConn)
+
+	start := time.Now()
+	for {
+		fmt.Println("\nUDP: Sending into channel")
+		chReply := new(shared.ChResult)
+		chReply.DummyJson = "UdpStuffReceived"
+		chReply.ConnObj = udpConn
+
+		ch <- *chReply
+
+		time.Sleep(1 * time.Millisecond)
+		elapsed := time.Since(start)
+		fmt.Println("UDP: Elapsed time sending channel: ", elapsed)
+		start = time.Now()
+	}
+}


### PR DESCRIPTION
Dummy UDP-server has same functionality as "dummy" (non-netcode)
TCP-server.

Currently no select multiplexing! But I checked it out

Note regarding the channel utilization: Both UDP and TCP
servers send in 1 ms interval into channel. The channel
is "sampled"  with a 2 ms interval. The UDP and TCp requests
are interleaved (i.e. every 4ms TCP and every 4 ms UDP)

Signed-off-by: monfron <simon.fronhoefer@gmail.com>